### PR TITLE
Use default Django base View

### DIFF
--- a/dmqtt/mosquitto.py
+++ b/dmqtt/mosquitto.py
@@ -1,18 +1,18 @@
 import json
 import logging
 
-from rest_framework.views import APIView
-
 from django.contrib.auth import authenticate
 from django.contrib.auth.signals import user_logged_in
 from django.http import HttpResponseForbidden, JsonResponse
 from django.urls import path
+from django.views import View
+from django.views.decorators.csrf import csrf_exempt
 
 logger = logging.getLogger(__name__)
 
 
 # https://github.com/iegomez/mosquitto-go-auth#http
-class GetUser(APIView):
+class GetUser(View):
     def post(self, request):
         data = json.loads(request.body.decode("utf-8"))
         user = authenticate(
@@ -28,13 +28,13 @@ class GetUser(APIView):
         return JsonResponse({"result": "ok"})
 
 
-class ACLCheck(APIView):
+class ACLCheck(View):
     def post(self, request):
         # TODO Proper auth
         return JsonResponse({"result": "ok"})
 
 
 urlpatterns = [
-    path("getuser", GetUser.as_view()),
-    path("aclcheck", ACLCheck.as_view()),
+    path("getuser", csrf_exempt(GetUser.as_view())),
+    path("aclcheck", csrf_exempt(ACLCheck.as_view())),
 ]

--- a/dmqtt/vernemq.py
+++ b/dmqtt/vernemq.py
@@ -1,18 +1,18 @@
 import json
 import logging
 
-from rest_framework.views import APIView
-
 from django.contrib.auth import authenticate
 from django.contrib.auth.signals import user_login_failed
 from django.http import HttpResponseForbidden, JsonResponse
 from django.urls import path
+from django.views import View
+from django.views.decorators.csrf import csrf_exempt
 
 logger = logging.getLogger(__name__)
 
 
 # https://docs.vernemq.com/plugindevelopment/webhookplugins#auth_on_register
-class OnRegister(APIView):
+class OnRegister(View):
     def post(self, request):
         data = json.loads(request.body.decode("utf-8"))
         if authenticate(request, username=data["username"], password=data["password"]):
@@ -27,21 +27,21 @@ class OnRegister(APIView):
 
 
 # https://docs.vernemq.com/plugindevelopment/webhookplugins#auth_on_subscribe
-class OnSubscribe(APIView):
+class OnSubscribe(View):
     def post(self, request):
         # TODO Proper auth
         return JsonResponse({"result": "ok"})
 
 
 # https://docs.vernemq.com/plugindevelopment/webhookplugins#auth_on_publish
-class OnPublish(APIView):
+class OnPublish(View):
     def post(self, request):
         # TODO Proper auth
         return JsonResponse({"result": "ok"})
 
 
 urlpatterns = [
-    path("auth_on_register", OnRegister.as_view()),
-    path("auth_on_subscribe", OnSubscribe.as_view()),
-    path("auth_on_publish", OnPublish.as_view()),
+    path("auth_on_register", csrf_exempt(OnRegister.as_view())),
+    path("auth_on_subscribe", csrf_exempt(OnSubscribe.as_view())),
+    path("auth_on_publish", csrf_exempt(OnPublish.as_view())),
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ packages = find:
 install_requires =
     Django>=3.2
     paho-mqtt
-    djangorestframework
 
 [options.packages.find]
 exclude = test

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+from django.test.client import Client
+
+
+class BaseTest(TestCase):
+    fixtures = ["default"]
+
+    def setUp(self):
+        super().setUp()
+        self.client = Client(enforce_csrf_checks=True)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,8 +7,19 @@ SECRET_KEY = "fake-key"
 INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.sessions",
     "tests",
     "dmqtt",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
 ROOT_URLCONF = "tests.urls"

--- a/tests/test_mosquitto.py
+++ b/tests/test_mosquitto.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
-from django.test import TestCase
+from . import BaseTest
 
 
-class LoginTest(TestCase):
+class LoginTest(BaseTest):
     fixtures = ["default"]
 
     @mock.patch("django.contrib.auth.signals.user_login_failed.send")
@@ -15,9 +15,9 @@ class LoginTest(TestCase):
             content_type="application/json",
         )
 
+        self.assertEqual(result.status_code, 200, result.content.decode("utf8"))
         self.assertEqual(signal_success.call_count, 1, "Called user_logged_in signal")
         self.assertEqual(signal_failed.call_count, 0, "Skipped user_login_failed signal")
-        self.assertEqual(result.status_code, 200, "Returned 200")
 
     @mock.patch("django.contrib.auth.signals.user_login_failed.send")
     @mock.patch("django.contrib.auth.signals.user_logged_in.send")
@@ -28,9 +28,9 @@ class LoginTest(TestCase):
             content_type="application/json",
         )
 
+        self.assertEqual(result.status_code, 403, result.content.decode("utf8"))
         self.assertEqual(signal_success.call_count, 0, "Skipped user_logged_in signal")
         self.assertEqual(signal_failed.call_count, 1, "Called user_login_failed signal")
-        self.assertEqual(result.status_code, 403, "Returned 403")
 
     @mock.patch("django.contrib.auth.signals.user_login_failed.send")
     @mock.patch("django.contrib.auth.signals.user_logged_in.send")
@@ -41,6 +41,6 @@ class LoginTest(TestCase):
             content_type="application/json",
         )
 
+        self.assertEqual(result.status_code, 403, result.content.decode("utf8"))
         self.assertEqual(signal_success.call_count, 0, "Skipped user_logged_in signal")
         self.assertEqual(signal_failed.call_count, 1, "Called user_login_failed signal")
-        self.assertEqual(result.status_code, 403, "Returned 403")


### PR DESCRIPTION
Switch to default django.views.View and remove the requirement on
djangorestframework. We still optionally pull in JSONDecoder if it is
already installed, due to its usefulness.