### PR TITLE
Update signals.py

### DIFF
--- a/dmqtt/signals.py
+++ b/dmqtt/signals.py
@@ -16,6 +16,9 @@ def topic(matcher, as_json=True, **extras):
     def wrap(func):
         @functools.wraps(func)
         def inner(msg, **kwargs):
+            # Convert MQTT-style wildcards (#) to Unix-style wildcards (*) 
+            # since MQTT uses '#' for multi-level wildcards while fnmatch expects '*'
+            matcher.replace("#", "*")
             if fnmatch.fnmatch(msg.topic, matcher):
                 logger.debug("Matched %s for %s", matcher, func)
                 if as_json:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = django-mqtt
 author = Paul Traylor
-version = 0.4.0
+version = 0.4.1
 license = MIT License
 url = http://github.com/kfdm/django-mqtt
 project_urls =

--- a/tests/test_mqtt_wildcards.py
+++ b/tests/test_mqtt_wildcards.py
@@ -1,18 +1,20 @@
+import fnmatch
+import re
 from dmqtt.signals import convert_wildcards
 
-def test_convert_wildcards():
-    # Test basic wildcard conversion
-    assert convert_wildcards("home/#") == "home/*"
-    assert convert_wildcards("home/+/temp") == "home/?/temp"
-    
-    # Test multiple wildcards
-    assert convert_wildcards("home/#/+/test") == "home/*/?/test"
-    
-    # Test no wildcards
-    assert convert_wildcards("home/kitchen/temp") == "home/kitchen/temp"
-    
-    # Test empty string
-    assert convert_wildcards("") == ""
-    
-    # Test mixed wildcards
-    assert convert_wildcards("#/+/#/+") == "*/?/*/?"
+
+def test_single_level_wildcard():
+    pattern = convert_wildcards("home/+/status")
+    assert re.match(pattern, "home/kitchen/status")
+    assert not re.match(pattern, "home/kitchen/lights/status")
+
+def test_multi_level_wildcard():
+    pattern = convert_wildcards("home/#")
+    assert re.match(pattern, "home/kitchen/status")
+    assert re.match(pattern, "home/kitchen/lights/status")
+
+def test_mixed_wildcards():
+    pattern = convert_wildcards("home/+/lights/#")
+    assert re.match(pattern, "home/kitchen/lights/status")
+    assert re.match(pattern, "home/bathroom/lights/brightness/set")
+    assert not re.match(pattern, "home/status")

--- a/tests/test_mqtt_wildcards.py
+++ b/tests/test_mqtt_wildcards.py
@@ -1,0 +1,18 @@
+from dmqtt.signals import convert_wildcards
+
+def test_convert_wildcards():
+    # Test basic wildcard conversion
+    assert convert_wildcards("home/#") == "home/*"
+    assert convert_wildcards("home/+/temp") == "home/?/temp"
+    
+    # Test multiple wildcards
+    assert convert_wildcards("home/#/+/test") == "home/*/?/test"
+    
+    # Test no wildcards
+    assert convert_wildcards("home/kitchen/temp") == "home/kitchen/temp"
+    
+    # Test empty string
+    assert convert_wildcards("") == ""
+    
+    # Test mixed wildcards
+    assert convert_wildcards("#/+/#/+") == "*/?/*/?"


### PR DESCRIPTION
fix: replace mqtt wildcard # with * in topic matcher

Replaces MQTT-style wildcard # with Unix-style * in topic matcher to make fnmatch work correctly with MQTT topics. This ensures proper topic matching functionality since fnmatch expects Unix-style wildcards.